### PR TITLE
Test needs this return otherwise failures will still return a pass

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -5,7 +5,7 @@ const companyName = 'Apple Inc.';
 
 describe('getQuote', function () {
   it('can get a quote', function () {
-    t.getQuote(symbol).then((quote) => {
+    return t.getQuote(symbol).then((quote) => {
       assert.ok(quote, 'Quote was not truthy.');
       assert.equal(symbol, quote.symbol, 'Symbol does not match: ' + symbol);
       assert.ok(quote.open, 'quote.open was not truthy.');


### PR DESCRIPTION
Found this while trying my own code (using this app as a base). This should stop the false-positives from this test if it ever fails in the future.